### PR TITLE
Ensure countdown is accurate when the server is lagging.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: NerdAlert
-version: 0.2.0
+version: 0.3.0
 author: totemo
 authors: [totemo]
 description: Handles important broadcast messages.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>nu.nerd</groupId>
 	<artifactId>NerdAlert</artifactId>
 	<name>NerdAlert</name>
-	<version>0.2.0</version>
+	<version>0.3.0</version>
 	<packaging>jar</packaging>
     <description>Handles important broadcast messages.</description>
     <url>https://github.com/NerdNu/NerdAlert</url>


### PR DESCRIPTION
Compute the countdown using the real-world clock rather than counting ticks, so it will be accurate when the server is lagging.