### PR TITLE
Start the countdown early by a *configurable* number of milliseconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Configuration
        persists on screen.
      * `event.title.fade_out_ticks` - Number of ticks the title display
        fades out.
+     * `event.title.early_ms` - Number of milliseconds to that the
+       countdown should be early so that it reaches 0. Do not set this higher
+       than 999: the subtitle at the 1 minute mark will be missed.
    * `event.subtitle.second` - Format string for subtitles showing a
      seconds count of 1.
    * `event.subtitle.seconds` - Format string for subtitles showing a

--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@ event:
     fade_in_ticks: 10
     display_ticks: 100
     fade_out_ticks: 20
+    early_ms: 500
 
   subtitle:
     second:  'in 1 second'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>nu.nerd</groupId>
 	<artifactId>NerdAlert</artifactId>
 	<name>NerdAlert</name>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<packaging>jar</packaging>
     <description>Handles important broadcast messages.</description>
     <url>https://github.com/NerdNu/NerdAlert</url>

--- a/src/nu/nerd/alert/Configuration.java
+++ b/src/nu/nerd/alert/Configuration.java
@@ -14,6 +14,7 @@ public class Configuration {
     public int EVENT_TITLE_FADE_IN_TICKS;
     public int EVENT_TITLE_DISPLAY_TICKS;
     public int EVENT_TITLE_FADE_OUT_TICKS;
+    public int EVENT_TITLE_EARLY_MS;
 
     // ------------------------------------------------------------------------
     /**
@@ -47,6 +48,7 @@ public class Configuration {
         EVENT_TITLE_FADE_IN_TICKS = getConfig().getInt("event.title.fade_in_ticks");
         EVENT_TITLE_DISPLAY_TICKS = getConfig().getInt("event.title.display_ticks");
         EVENT_TITLE_FADE_OUT_TICKS = getConfig().getInt("event.title.fade_out_ticks");
+        EVENT_TITLE_EARLY_MS = getConfig().getInt("event.title.early_ms");
     }
 
     // ------------------------------------------------------------------------

--- a/src/nu/nerd/alert/CountdownTask.java
+++ b/src/nu/nerd/alert/CountdownTask.java
@@ -73,7 +73,7 @@ public class CountdownTask implements Runnable {
      */
     @Override
     public void run() {
-        int elapsedSeconds = (int) (System.currentTimeMillis() + EARLY_MS - _startTime) / 1000;
+        int elapsedSeconds = (int) (System.currentTimeMillis() + _config.EVENT_TITLE_EARLY_MS - _startTime) / 1000;
         int remaining = _duration - elapsedSeconds;
         if (_lastSeconds != remaining) {
             _lastSeconds = remaining;
@@ -103,7 +103,7 @@ public class CountdownTask implements Runnable {
         if (seconds == 0) {
             number = 0;
             key = "now";
-        } else if (seconds > 0 && seconds % 60 == 0) {
+        } else if (seconds % 60 == 0) {
             number = seconds / 60;
             key = (number == 1) ? "minute" : "minutes";
         } else {
@@ -152,12 +152,6 @@ public class CountdownTask implements Runnable {
     }
 
     // ------------------------------------------------------------------------
-    /**
-     * The countdown times are shown early by this many milliseconds so that the
-     * countdown can go right to 0.
-     */
-    protected static final int EARLY_MS = 100;
-
     /**
      * Configuration.
      */


### PR DESCRIPTION
Start the countdown early by a *configurable* number of milliseconds.

Apparently, 100ms is not enough under heavy load.  So just make the earliness configurable.