### PR TITLE
Updated to use the new Bukkit API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ hs_err_pid*
 .settings
 .classpath
 
+# IntelliJ
+.idea/
+*.iml
+
 # Build:
 /classes/
 target/

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.11.2-R0.1-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/nu/nerd/alert/CountdownTask.java
+++ b/src/nu/nerd/alert/CountdownTask.java
@@ -2,6 +2,7 @@ package nu.nerd.alert;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 // ----------------------------------------------------------------------------
@@ -125,13 +126,10 @@ public class CountdownTask implements Runnable {
      * @param fadeOutTicks the number of ticks to fade out.
      */
     protected static void showTitle(String title, String subtitle, int fadeInTicks, int displayTicks, int fadeOutTicks) {
-        String cmdTime = String.format("title @a times %d %d %d", fadeInTicks, displayTicks, fadeOutTicks);
-        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), cmdTime);
-        String cmdTitle = String.format("title @a title {\"text\":\"%s\"}", ChatColor.translateAlternateColorCodes('&', title));
-        Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), cmdTitle);
-        if (subtitle != null) {
-            String cmdSub = String.format("title @a subtitle {\"text\":\"%s\"}", ChatColor.translateAlternateColorCodes('&', subtitle));
-            Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), cmdSub);
+        title = ChatColor.translateAlternateColorCodes('&', title);
+        subtitle = ChatColor.translateAlternateColorCodes('&', subtitle);
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+            player.sendTitle(title, subtitle, fadeInTicks, displayTicks, fadeOutTicks);
         }
     }
 


### PR DESCRIPTION
Now that there appears to be [a stable way to send titles to players](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#sendTitle(java.lang.String,%20java.lang.String,%20int,%20int,%20int)) from the Bukkit API, I figured it would be worth exploring the possibility of switching to that instead of spamming console with dispatched vanilla title commands.

I made the changes and did some basic testing, but I don't know the plugin enough to guess at whether it would break anything.